### PR TITLE
feat: recentPage에 localStorage데이터 적용(#49)

### DIFF
--- a/src/pages/RecentListPage.jsx
+++ b/src/pages/RecentListPage.jsx
@@ -2,16 +2,47 @@ import React, { Component } from 'react';
 
 import { Filter, RecentProductList } from 'components/recentList';
 
-import PRODUCTS from 'fixture/productsData';
-
 class RecentListPage extends Component {
+  state = {
+    isLoading: true,
+    clickedItems : []
+  }
+
   render() {
     return (
       <>
-        <Filter />
-        <RecentProductList products={PRODUCTS} />
+      {
+        this.state.isLoading
+        ? <h1>로딩중입니다.</h1>
+        : (
+          this.state.clickedItems.length === 0
+          ? <h1>클릭한 아이템이 없습니다.</h1>
+          : <>
+              <Filter />
+              <RecentProductList products={this.state.clickedItems} />
+            </>
+        )
+      }
       </>
     );
+  }
+
+  componentDidMount() {
+    const clickedItems = JSON.parse(localStorage.getItem('viewed'));
+    //실제 API가 있을 경우, 비동기로 들어올 것을 고려해 시뮬레이팅함.
+    setTimeout(() => {
+      if (!clickedItems) {
+        this.setState({
+          isLoading: false,
+          clickedItems: []
+        })
+      } else {
+        this.setState({
+          isLoading: false,
+          clickedItems
+        });
+      }
+    }, 1500);
   }
 }
 


### PR DESCRIPTION
Resolve #49 
- 데이터가 비어있는 경우, 로직처리
- 로딩시 보여줄 메세지 적용
- 조회되었던 상품만 localStorage에서 불러옴