### PR TITLE
[fix] localStorage 중복방지관련 shallow compare문제 해결 (#52)

### DIFF
--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -32,7 +32,7 @@ class ProductPage extends Component {
   };
 
   componentDidUpdate = (_prevProps, prevState) => {
-    if (this.state.latestClickedItem !== prevState.latestClickedItem) {
+    if (this.state.latestClickedItem?.title !== prevState.latestClickedItem?.title) {
       this.handleStateChange({
         key: 'clickedItem',
         value: [this.state.latestClickedItem, ...this.state.clickedItem],


### PR DESCRIPTION
Resolve #52 
- localStorage에 같은 상품 중복으로 저장되는 문제 해결
- shallow compare로 인해 componentDidUpdate가 실행되지 않도록 처리